### PR TITLE
Fix Version Checking and Change Data URL

### DIFF
--- a/SS14.Launcher/ConfigConstants.cs
+++ b/SS14.Launcher/ConfigConstants.cs
@@ -5,8 +5,12 @@ namespace SS14.Launcher;
 
 public static class ConfigConstants
 {
-    public const string CurrentLauncherVersion = "51";
-    public static readonly bool DoVersionCheck = true;
+    public const string CurrentLauncherVersion = "1.0.2";
+    #if RELEASE
+    public const bool DoVersionCheck = true;
+    #else
+    public const bool DoVersionCheck = false;
+    #endif
 
     // Refresh login tokens if they're within <this much> of expiry.
     public static readonly TimeSpan TokenRefreshThreshold = TimeSpan.FromDays(15);
@@ -50,8 +54,7 @@ public static class ConfigConstants
     ]);
 
     private static readonly UrlFallbackSet LauncherDataBaseUrl = new([
-        "https://launcher-data.cdn.spacestation14.com/",
-        "https://launcher-data.fallback.cdn.spacestation14.com/",
+        "http://assets.simplestation.org/launcher/",
     ]);
 
     public static readonly UrlFallbackSet RobustBuildsManifest = RobustBuildsBaseUrl + "manifest.json";

--- a/SS14.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowViewModel.cs
@@ -172,9 +172,7 @@ public sealed class MainWindowViewModel : ViewModelBase, IErrorOverlayOwner
     {
         // await Task.Delay(1000);
         if (!ConfigConstants.DoVersionCheck)
-        {
             return;
-        }
 
         await _infoManager.LoadTask;
         if (_infoManager.Model == null)


### PR DESCRIPTION
This was happening, stupid. Especially in Debug, why was this check occurring in Debug, when you know for a fact the version doesn't matter?

![image](https://github.com/user-attachments/assets/50de040b-789f-46d3-9a10-4a42bb59d667)
