### PR TITLE
Change Assembly Version to Match Launcher Version

### DIFF
--- a/Launcher.props
+++ b/Launcher.props
@@ -8,6 +8,6 @@
         3. Local dev SS14.Loader launching code.
         -->
         <TargetFramework>net8.0</TargetFramework>
-        <Version>0.29.1</Version>
+        <Version>1.2.1</Version>
     </PropertyGroup>
 </Project>

--- a/SS14.Launcher/ConfigConstants.cs
+++ b/SS14.Launcher/ConfigConstants.cs
@@ -6,7 +6,7 @@ namespace SS14.Launcher;
 
 public static class ConfigConstants
 {
-    public const string CurrentLauncherVersion = "1.2.0";
+    public const string CurrentLauncherVersion = "1.2.1";
     #if RELEASE
     public const bool DoVersionCheck = true;
     #else


### PR DESCRIPTION
Bottom right of the launcher uses a random other value than the configured launcher version for some reason.