### PR TITLE
Introduce upstream user agent

### DIFF
--- a/SS14.Launcher/Program.cs
+++ b/SS14.Launcher/Program.cs
@@ -214,8 +214,9 @@ internal static class Program
         var locator = Locator.CurrentMutable;
 
         var http = HappyEyeballsHttp.CreateHttpClient();
-        // http.DefaultRequestHeaders.UserAgent.Add(
-        //     new ProductInfoHeaderValue(LauncherVersion.Name, LauncherVersion.Version?.ToString()));
+        http.DefaultRequestHeaders.UserAgent.Add(
+            new ProductInfoHeaderValue("SS14.Launcher", "0.36.1")); // "I don't trust you, but if hub behavior changes they're malicious anyway." So don't.
+                                                                    // Change to non-obsolete versions of upstream every few months.
         http.DefaultRequestHeaders.Add("SS14-Launcher-Fingerprint", cfg.Fingerprint.ToString());
         Locator.CurrentMutable.RegisterConstant(http);
 


### PR DESCRIPTION
SS:B should remain accessible regardless of upstream policy, so I'm taking the final step in increasing accessibility for the entire zoo this game spawned.

The next upstream maintainer to look at this PR will just prove themselves a larger issue for the SS14 community as a whole. I know you're reading this, and you're no better than some Eastern political figures I could name.

In the future, it'd be best to make this auth-dependent, but as of current I am fed up.